### PR TITLE
Add editor config and macOS tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[package.json]
+indent_size = 2

--- a/client/src/modules/ui/components/bdbutton.vue
+++ b/client/src/modules/ui/components/bdbutton.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bd-settings-wrapper">
+    <div :class="['bd-settings-wrapper', 'platform-' + this.platform]">
         <div class="bd-settings-button" :class="{active: this.isActive}" @click="showSettings">
             <div class="bd-settings-button-btn"></div>
         </div>
@@ -14,7 +14,8 @@
         },
         data() {
             return {
-                isActive: false
+                isActive: false,
+                platform: global.process.platform
             }
         },
         methods: {

--- a/client/src/styles/partials/bdsettings.scss
+++ b/client/src/styles/partials/bdsettings.scss
@@ -70,6 +70,18 @@
     &.active {
         width: 900px;
     }
+
+    .platform-darwin & {
+        top: 0px;
+
+        .bd-sidebar-view .bd-sidebar-region,
+        .bd-sidebar-view .bd-content-region {
+            padding-top: 22px;
+        }
+        .bd-settings-x {
+            top: 22px;
+        }
+    }
 }
 
 .bd-settings.active {


### PR DESCRIPTION
Move settings view on macOS as it doesn't have the same title bar as Windows

![screen shot 2018-01-20 at 00 40 27](https://user-images.githubusercontent.com/8474065/35177815-e9f3212c-fd7a-11e7-89a3-ae7010b7e8f3.png)
