### PR TITLE
Add keyboard shortcut

### DIFF
--- a/client/src/modules/ui/vue/components/BdSettingsWrapper.vue
+++ b/client/src/modules/ui/vue/components/BdSettingsWrapper.vue
@@ -10,17 +10,35 @@
 
     const methods = { showSettings, hideSettings };
 
+    let keydownEvent;
+
     export default {
         components,
         methods,
         data() {
-            return { active: false }
+            return {
+                active: false,
+                platform: global.process.platform
+            }
         },
         created: function() {
-            window.addEventListener('keyup', e => {
-                if (e.which !== 27) return;
-                this.hideSettings();
+            window.addEventListener('keydown', keydownEvent = e => {
+                if (this.active) {
+                    if (e.which === 27)
+                        this.hideSettings();
+                } else {
+                    if (global.process.platform == 'darwin' && e.metaKey && e.key == 'b')
+                        this.showSettings();
+                    else if (global.process.platform != 'darwin' && e.ctrlKey && e.key == 'b')
+                        this.showSettings();
+                    else return;
+                }
+
+                e.stopImmediatePropagation();
             });
+        },
+        destroyed: function() {
+            window.removeEventListener('keydown', keydownEvent);
         }
     }
 </script>

--- a/client/src/modules/ui/vue/components/BdSettingsWrapper.vue
+++ b/client/src/modules/ui/vue/components/BdSettingsWrapper.vue
@@ -10,7 +10,7 @@
 
     const methods = { showSettings, hideSettings };
 
-    let keydownEvent;
+    let globalKeyListener;
 
     export default {
         components,
@@ -21,24 +21,21 @@
                 platform: global.process.platform
             }
         },
-        created: function() {
-            window.addEventListener('keydown', keydownEvent = e => {
-                if (this.active) {
-                    if (e.which === 27)
-                        this.hideSettings();
-                } else {
-                    if (global.process.platform == 'darwin' && e.metaKey && e.key == 'b')
-                        this.showSettings();
-                    else if (global.process.platform != 'darwin' && e.ctrlKey && e.key == 'b')
-                        this.showSettings();
-                    else return;
+        created: function () {
+            window.addEventListener('keyup', globalKeyListener = e => {
+                if (this.active && e.which === 27) {
+                    this.hideSettings();
+                    return;
                 }
+                if (!e.metaKey && !e.ctrlKey && e.key !== 'b') return;
+
+                !this.active ? this.showSettings() : this.hideSettings();
 
                 e.stopImmediatePropagation();
             });
         },
-        destroyed: function() {
-            window.removeEventListener('keydown', keydownEvent);
+        destroyed: function () {
+            if (globalKeyListener) window.removeEventListener('keyup', globalKeyListener);
         }
     }
 </script>

--- a/client/src/modules/ui/vue/components/templates/BdSettingsWrapper.html
+++ b/client/src/modules/ui/vue/components/templates/BdSettingsWrapper.html
@@ -1,4 +1,4 @@
-<div class="bd-settings-wrapper" :class="{active: active}">
+<div class="bd-settings-wrapper" :class="[{active: active}, 'platform-' + this.platform]">
     <div class="bd-settings-button" :class="{active: active}" @click="showSettings">
         <div class="bd-settings-button-btn"></div>
     </div>


### PR DESCRIPTION
Adds a keyboard shortcut to open the settings menu. This is currently `Ctrl + B` or `Cmd + B` on macOS.

Maybe this could be an option?

Also fixes a bug where pressing escape with another dialog open closes both at once.