### PR TITLE
Adjust reload button for plugin view

### DIFF
--- a/client/src/modules/ui/vue/components/bd/PluginsView.vue
+++ b/client/src/modules/ui/vue/components/bd/PluginsView.vue
@@ -61,6 +61,7 @@
 
     .bd-pluginsView .bd-button {
         display: flex;
+        position: relative;
     }
 
     .bd-pluginsView .bd-button h3 {
@@ -81,6 +82,8 @@
         justify-content: center;
         width: 30px;
         height: 30px;
+        position: absolute;
+        right: 10px;
     }
 
     .bd-pluginsView .bd-button {
@@ -93,6 +96,6 @@
     }
 
     .bd-material-button:hover {
-        background: #2d2f34;
+        background: #29569a;
     }
 </style>


### PR DESCRIPTION
Just a small nitpick, but moving the refresh button over and changing the hover colour to better fit. Would probably be good to add some sort of highlight colour for the BDBlue, for other components that  might happen to pop up and act the same. Feel free to change the colour to one you see fit.

After:
![After Image](https://i.imgur.com/KNKm8eL.png)

Before:
![Before Image](https://i.imgur.com/IKaRQPw.png)
