### PR TITLE
Add app menu

### DIFF
--- a/client/src/modules/core/bdipc.js
+++ b/client/src/modules/core/bdipc.js
@@ -5,14 +5,18 @@
  * https://github.com/JsSucks - https://betterdiscord.net
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree. 
+ * LICENSE file in the root directory of this source tree.
 */
 
 const { ipcRenderer } = require('electron');
 
 class BDIpc {
     static on(channel, cb) {
-        ipcRenderer.on(channel, (event, message) => cb(event, message));
+        ipcRenderer.on(channel, cb.__ipc_binding = (event, message) => cb(event, message));
+    }
+
+    static off(channel, cb) {
+        ipcRenderer.removeListener(channel, cb.__ipc_binding);
     }
 
     static async send(channel, message) {

--- a/client/src/modules/ui/components/BdSettings.vue
+++ b/client/src/modules/ui/components/BdSettings.vue
@@ -1,8 +1,7 @@
 <template src="./templates/BdSettings.html"></template>
 
 <script>
-
-    const { Settings } = require('../../');
+    const { BDIpc, Settings } = require('../../');
 
     /*Imports*/
     import { SidebarView, Sidebar, SidebarItem, ContentColumn } from './sidebar';
@@ -52,6 +51,12 @@
         return item.id === this.activeIndex;
     }
 
+    function activateContent(s) {
+        const item = this.sidebarItems.find(item => item.contentid === s);
+        if (item.active) return;
+        this.itemOnClick(item.id);
+    }
+
     function enableSetting(cat, id) {
         switch (cat) {
             case 'core':
@@ -66,7 +71,10 @@
         }
     }
 
-    const methods = { itemOnClick, animatingContent, activeContent, enableSetting, disableSetting };
+    const methods = { itemOnClick, animatingContent, activeContent, activateContent, enableSetting, disableSetting };
+
+    let menuListener;
+    let ipcEventListener;
 
     export default {
         components,
@@ -91,6 +99,13 @@
             if (this.active) return;
             this.activeIndex = this.lastActiveIndex = -1;
             this.sidebarItems.forEach(item => item.active = false);
+        },
+        created: function () {
+            BDIpc.on('bd-show-menu', ipcEventListener = (e, content) => this.activateContent(content));
+        },
+        destroyed: function () {
+            if (menuListener) window.removeEventListener('bd-show-plugins', menuListener);
+            if (ipcEventListener) BDIpc.off('bd-show-menu', ipcEventListener);
         }
     }
 </script>

--- a/client/src/modules/ui/components/BdSettingsWrapper.vue
+++ b/client/src/modules/ui/components/BdSettingsWrapper.vue
@@ -1,5 +1,7 @@
 <template src="./templates/BdSettingsWrapper.html"></template>
 <script>
+    const { BDIpc } = require('../../');
+
     /*Imports*/
     import BdSettings from './BdSettings.vue';
     const components = { BdSettings };
@@ -11,6 +13,9 @@
     const methods = { showSettings, hideSettings };
 
     let globalKeyListener;
+    let ipcEventShow;
+    let ipcEventToggle;
+    let ipcEventHide;
 
     export default {
         components,
@@ -23,19 +28,19 @@
         },
         created: function () {
             window.addEventListener('keyup', globalKeyListener = e => {
-                if (this.active && e.which === 27) {
-                    this.hideSettings();
-                    return;
-                }
-                if (!e.metaKey && !e.ctrlKey || e.key !== 'b') return;
-
-                !this.active ? this.showSettings() : this.hideSettings();
-
+                if (!this.active || e.which !== 27) return;
+                this.hideSettings();
                 e.stopImmediatePropagation();
             });
+            BDIpc.on('bd-toggle-menu', ipcEventToggle = () => !this.active ? this.showSettings() : this.hideSettings());
+            BDIpc.on('bd-show-menu', ipcEventShow = () => this.showSettings());
+            BDIpc.on('bd-hide-menu', ipcEventHide = () => this.hideSettings());
         },
         destroyed: function () {
             if (globalKeyListener) window.removeEventListener('keyup', globalKeyListener);
+            if (ipcEventShow) BDIpc.off('bd-toggle-menu', ipcEventShow);
+            if (ipcEventToggle) BDIpc.off('bd-show-menu', ipcEventToggle);
+            if (ipcEventHide) BDIpc.off('bd-hide-menu', ipcEventHide);
         }
     }
 </script>

--- a/core/src/main.js
+++ b/core/src/main.js
@@ -5,7 +5,7 @@
  * https://github.com/JsSucks - https://betterdiscord.net
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree. 
+ * LICENSE file in the root directory of this source tree.
 */
 
 const path = require('path');
@@ -23,7 +23,7 @@ const __DEV = {
 const __pluginPath = path.resolve(__dirname, '..', '..', 'tests', 'plugins');
 const __themePath = path.resolve(__dirname, '..', '..', 'tests', 'themes');
 
-const { Utils, FileUtils, BDIpc, Config, WindowUtils, CSSEditor } = require('./modules');
+const { Utils, FileUtils, BDIpc, Config, WindowUtils, CSSEditor, AppMenu } = require('./modules');
 const { BrowserWindow } = require('electron');
 
 const Common = {};
@@ -38,7 +38,6 @@ const dummyArgs = {
 };
 
 console.log(dummyArgs);
-
 
 class Comms {
 
@@ -105,7 +104,9 @@ class BetterDiscord {
             this.windowUtils.send('did-navigate-in-page', { event, url, isMainFrame });
         });
 
-        BDIpc.on('bd-sendToDiscord', event => this.windowUtils.send(event.args.channel, event.args.message))
+        BDIpc.on('bd-sendToDiscord', event => this.windowUtils.send(event.args.channel, event.args.message));
+
+        AppMenu.setState({ windowUtils: this.windowUtils });
 
         setTimeout(() => {
             if (__DEV) { this.injectScripts(); }
@@ -155,6 +156,4 @@ class BetterDiscord {
 
 }
 
-module.exports = {
-    BetterDiscord
-}
+module.exports = { BetterDiscord };

--- a/core/src/modules/appmenu.js
+++ b/core/src/modules/appmenu.js
@@ -1,0 +1,274 @@
+/**
+ * BetterDiscord App Menu Module
+ * Copyright (c) 2015-present JsSucks - https://github.com/JsSucks
+ * All rights reserved.
+ * https://github.com/JsSucks - https://betterdiscord.net
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const { Module } = require('./modulebase');
+const { BDIpc } = require('./bdipc');
+const { BetterDiscord } = require('../main.js');
+const { app, shell, Menu, MenuItem, BrowserWindow } = require('electron');
+const process = require('process');
+
+// This is loaded before Discord's own menu - this stops it from being overridden
+const { setApplicationMenu } = Menu;
+Menu.setApplicationMenu = () => {};
+
+/* Discord's own menu uses app.emit(MenuEventConstant) to do things inside the renderer. MenuEventConstant can be:
+ * - CHECK_FOR_UPDATES, which evaluates to "menu:check-for-updates",
+ * - OPEN_SETTINGS, which evaluates to "menu:open-settings", and
+ * - OPEN_HELP, which evaluates to "menu:open-help"
+ */
+
+class AppMenu extends Module {
+
+    initMenu() {
+        const menu = new Menu();
+
+        if (process.platform === 'darwin')
+            menu.append(this.appMenu);
+        else menu.append(this.fileMenu);
+
+        menu.append(this.editMenu);
+        menu.append(this.viewMenu);
+        menu.append(this.bdMenu);
+        menu.append(this.windowMenu);
+        menu.append(this.helpMenu);
+
+        setApplicationMenu(this.menu = menu);
+        this.initted = true;
+    }
+
+    get appMenu() {
+        if (this._appMenu) return this._appMenu;
+
+        const appMenu = new MenuItem({
+            label: app.getName(),
+            submenu: [
+                {role: 'about', label: 'About Discord'},
+                {type: 'separator'},
+                {
+                    label: 'Check for Updates...',
+                    click: () => app.emit('menu:check-for-updates')
+                },
+                {
+                    label: 'Preferences',
+                    click: () => app.emit('menu:open-settings'),
+                    accelerator: process.platform === 'darwin' ? 'Cmd+,' : 'Ctrl+,'
+                },
+                {type: 'separator'},
+                {role: 'services', submenu: []},
+                {type: 'separator'},
+                {role: 'hide', label: 'Hide Discord'},
+                {role: 'hideothers'},
+                {role: 'unhide'},
+                {type: 'separator'},
+                {role: 'quit', label: 'Quit Discord'}
+            ]
+        });
+
+        return this._appMenu = appMenu;
+    }
+
+    get fileMenu() {
+        if (this._fileMenu) return this._fileMenu;
+
+        const fileMenu = new MenuItem({
+            label: app.getName(),
+            submenu: [
+                {
+                    label: 'Options',
+                    click: () => app.emit('menu:open-settings'),
+                    accelerator: process.platform === 'darwin' ? 'Cmd+,' : 'Ctrl+,'
+                },
+                {type: 'separator'},
+                {role: 'quit', label: 'Exit'}
+            ]
+        });
+
+        return this._fileMenu = fileMenu;
+    }
+
+    get editMenu() {
+        if (this._editMenu) return this._editMenu;
+
+        const editMenu = new MenuItem({
+            label: 'Edit',
+            submenu: [
+                {role: 'undo'},
+                {role: 'redo'},
+                {type: 'separator'},
+                {role: 'cut'},
+                {role: 'copy'},
+                {role: 'paste'},
+                {role: 'pasteandmatchstyle'},
+                {role: 'delete'},
+                {role: 'selectall'}
+            ].concat(process.platform === 'darwin' ? [
+                {type: 'separator'},
+                {
+                    label: 'Speech',
+                    submenu: [
+                        {role: 'startspeaking'},
+                        {role: 'stopspeaking'}
+                    ]
+                }
+            ] : [])
+        });
+
+        return this._editMenu = editMenu;
+    }
+
+    get viewMenu() {
+        if (this._viewMenu) return this._viewMenu;
+
+        const viewMenu = new MenuItem({
+            label: 'View',
+            submenu: [
+                {role: 'reload'},
+                {role: 'forcereload'},
+                {role: 'toggledevtools'},
+                {type: 'separator'},
+                {role: 'resetzoom'},
+                {role: 'zoomin'},
+                {role: 'zoomout'},
+                {type: 'separator'},
+                {role: 'togglefullscreen'}
+            ]
+        });
+
+        return this._viewMenu = viewMenu;
+    }
+
+    get bdMenu() {
+        if (this._bdMenu) return this._bdMenu;
+
+        const bdMenu = new MenuItem({
+            label: 'BetterDiscord',
+            submenu: [
+                {
+                    label: 'Toggle BetterDiscord',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-toggle-menu'); },
+                    accelerator: process.platform === 'darwin' ? 'Cmd+B' : 'Ctrl+B'
+                },
+                {
+                    label: 'About BetterDiscord',
+                    click: () => shell.openExternal('https://betterdiscord.net')
+                },
+                {type: 'separator'},
+                {
+                    label: 'Show Core Settings',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-show-menu', 'core'); }
+                },
+                {
+                    label: 'Show UI Settings',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-show-menu', 'ui'); }
+                },
+                {
+                    label: 'Show Emote Settings',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-show-menu', 'emotes'); }
+                },
+                {
+                    label: 'Show CSS Editor',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-show-menu', 'css'); },
+                    accelerator: process.platform === 'darwin' ? 'Cmd+S' : 'Ctrl+S'
+                },
+                {type: 'separator'},
+                {
+                    label: 'Show Plugins',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-show-menu', 'plugins'); }
+                },
+                {
+                    label: 'Show Themes',
+                    click: () => { this.webContents.focus(); this.webContents.send('bd-show-menu', 'themes'); }
+                }
+            ]
+        });
+
+        return this._bdMenu = bdMenu;
+    }
+
+    get windowMenu() {
+        if (this._windowMenu) return this._windowMenu;
+
+        const close = new MenuItem({
+            label: 'Close',
+            click: () => {
+                const focusedWindow = BrowserWindow.getFocusedWindow();
+                if (!focusedWindow) return;
+                if (focusedWindow === this.windowUtils.window) {
+                    // win.hide() is fine on Windows (Linux?) and is likely what Discord uses,
+                    // but on macOS they use app.hide() on the menu item.
+                    // It basically minimizes all windows but with no animation.
+                    if (process.platform === 'darwin') {
+                        // Main window and on macOS - if it's the only window hide the app, otherwise minimize it
+                        BrowserWindow.getAllWindows().find(w => !w.isMinimized() && w !== focusedWindow) ? focusedWindow.minimize() : app.hide();
+                    } else focusedWindow.hide(); // Main window but not macOS - hide
+                } else focusedWindow.close(); // Not the main window - close
+            },
+            accelerator: process.platform === 'darwin' ? 'Cmd+W' : 'Ctrl+W'
+        });
+
+        const windowMenu = new MenuItem({
+            role: 'window',
+            submenu: process.platform === 'darwin' ? [
+                close,
+                {role: 'minimize'},
+                {role: 'zoom'},
+                {type: 'separator'},
+                {role: 'front'}
+            ] : [
+                {role: 'minimize'},
+                close
+            ]
+        });
+
+        return this._windowMenu = windowMenu;
+    }
+
+    get helpMenu() {
+        if (this._helpMenu) return this._helpMenu;
+
+        const helpMenu = new MenuItem({
+            role: 'help',
+            submenu: [
+                {
+                    label: 'Discord Help',
+                    click: () => app.emit('menu:open-help')
+                },
+                {
+                    label: 'View the Source Code on GitHub',
+                    click: () => shell.openExternal('https://github.com/JsSucks/BetterDiscordApp')
+                }
+            ]
+        });
+
+        return this._helpMenu = helpMenu;
+    }
+
+    stateChanged(oldState, newState) {
+        if (this.initted || !newState.windowUtils) return;
+
+        this.initMenu();
+    }
+
+    getMenu() {
+        return this.menu;
+    }
+
+    get windowUtils() {
+        return this.state.windowUtils;
+    }
+
+    get webContents() {
+        return this.windowUtils.webContents;
+    }
+
+}
+
+const _instance = new AppMenu();
+module.exports = { AppMenu: _instance };

--- a/core/src/modules/index.js
+++ b/core/src/modules/index.js
@@ -2,3 +2,4 @@ export { BDIpc } from './bdipc';
 export { Utils, FileUtils, WindowUtils } from './utils';
 export { Config } from './config';
 export { CSSEditor } from './csseditor';
+export { AppMenu } from './appmenu';

--- a/core/src/modules/modulebase.js
+++ b/core/src/modules/modulebase.js
@@ -5,7 +5,7 @@
  * https://github.com/JsSucks - https://betterdiscord.net
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree. 
+ * LICENSE file in the root directory of this source tree.
 */
 
 /*
@@ -16,7 +16,7 @@ class Module {
 
     constructor(args) {
         this.__ = {
-            state: args,
+            state: args || {},
             args
         }
         this.init();
@@ -25,6 +25,12 @@ class Module {
     init() {
         if (this.bindings) this.bindings();
         if (this.setInitialState) this.setInitialState(this.state);
+    }
+
+    setState(newState) {
+        const oldState = this.state;
+        Object.assign(this.__.state, newState);
+        if (this.stateChanged) this.stateChanged(oldState, newState);
     }
 
     set args(t) {}


### PR DESCRIPTION
Added a custom application menu to replace Discord's limited one. This doesn't actually change anything visually on Windows (and Linux?) but is still used for keyboard shortcuts.

![screen shot 2018-01-23 at 22 24 06](https://user-images.githubusercontent.com/8474065/35304122-505a4a80-008c-11e8-8565-ddba14703e39.png)
