### PR TITLE
Add plugin exports

### DIFF
--- a/client/src/modules/contentmanager.js
+++ b/client/src/modules/contentmanager.js
@@ -112,6 +112,8 @@ export default class {
             const readConfig = await this.readConfig(contentPath);
             const mainPath = path.join(contentPath, readConfig.main);
 
+            readConfig.defaultConfig = readConfig.defaultConfig || [];
+
             const userConfig = {
                 enabled: false,
                 config: readConfig.defaultConfig
@@ -187,5 +189,17 @@ export default class {
     static getContentById(id) { return this.localContent.find(c => c.id === id) }
     static getContentByPath(path) { return this.localContent.find(c => c.contentPath === path) }
     static getContentByDirName(dirName) { return this.localContent.find(c => c.dirName === dirName) }
+
+    static waitForContent(content_id) {
+        return new Promise((resolve, reject) => {
+            const check = () => {
+                const content = this.getContentById(content_id);
+                if (content) return resolve(content);
+
+                setTimeout(check, 100);
+            };
+            check();
+        });
+    }
 
 }

--- a/client/src/modules/plugin.js
+++ b/client/src/modules/plugin.js
@@ -27,13 +27,15 @@ export default class {
     get main() { return this.__pluginInternals.main }
     get defaultConfig() { return this.configs.defaultConfig }
     get userConfig() { return this.configs.userConfig }
+    get id() { return this.info.id || this.info.name.replace(/[^a-zA-Z0-9-]/g, '-').replace(/--/g, '-') }
     get name() { return this.info.name }
     get authors() { return this.info.authors }
     get version() { return this.info.version }
     get pluginPath() { return this.paths.contentPath }
     get dirName() { return this.paths.dirName }
     get enabled() { return this.userConfig.enabled }
-    get pluginConfig() { return this.userConfig.config }
+    get pluginConfig() { return this.userConfig.config || [] }
+    get exports() { return this._exports ? this._exports : (this._exports = this.getExports()) }
 
     getSetting(setting_id, category_id) {
         for (let category of this.pluginConfig) {
@@ -85,10 +87,8 @@ export default class {
     }
 
     start() {
-        if (this.onStart) {
-            const started = this.onStart();
-            if (!started) return false;
-        }
+        if (this.onstart && !this.onstart()) return false;
+        if (this.onStart && !this.onStart()) return false;
 
         if (!this.enabled) {
             this.userConfig.enabled = true;
@@ -99,10 +99,8 @@ export default class {
     }
 
     stop() {
-        if (this.onStop) {
-            const stopped = this.onStop();
-            if (!stopped) return false;
-        }
+        if (this.onstop && !this.onstop()) return false;
+        if (this.onStop && !this.onStop()) return false;
 
         this.userConfig.enabled = false;
         this.saveConfiguration();

--- a/client/src/modules/pluginapi.js
+++ b/client/src/modules/pluginapi.js
@@ -9,6 +9,8 @@
 */
 
 import { ClientLogger as Logger } from 'common';
+import PluginManager from './pluginmanager';
+import ThemeManager from './thememanager';
 import Events from './events';
 
 export default class PluginApi {
@@ -63,5 +65,38 @@ export default class PluginApi {
             unsubscribeAll: this.eventUnsubscribeAll.bind(this)
         }
     }
-    
+
+    async getPlugin(plugin_id) {
+        // This should require extra permissions
+        return await PluginManager.waitForPlugin(plugin_id);
+    }
+    getPlugins(plugin_id) {
+        return PluginManager.localContent.map(plugin => plugin.id);
+    }
+    get Plugins() {
+        return {
+            getPlugin: this.getPlugin.bind(this),
+            getPlugins: this.getPlugins.bind(this)
+        };
+    }
+
+    async getTheme(theme_id) {
+        // This should require extra permissions
+        return await ThemeManager.waitForContent(theme_id);
+    }
+    getThemes(plugin_id) {
+        return ThemeManager.localContent.map(theme => theme.id);
+    }
+    get Themes() {
+        return {
+            getTheme: this.getTheme.bind(this),
+            getThemes: this.getThemes.bind(this)
+        };
+    }
+
+    async require(plugin_id) {
+        const plugin = await PluginManager.waitForPlugin(plugin_id);
+        return plugin.exports;
+    }
+
 }

--- a/client/src/modules/pluginmanager.js
+++ b/client/src/modules/pluginmanager.js
@@ -99,4 +99,6 @@ export default class extends ContentManager {
     static get getPluginByPath() { return this.getContentByPath }
     static get getPluginByDirName() { return this.getContentByDirName }
 
+    static get waitForPlugin() { return this.waitForContent }
+
 }

--- a/tests/plugins/Example 3/config.json
+++ b/tests/plugins/Example 3/config.json
@@ -1,0 +1,10 @@
+{
+    "info": {
+        "id": "example-plugin-3",
+        "name": "Example Plugin 3",
+        "authors": [ "Samuel Elliott" ],
+        "version": 1.0,
+        "description": "A plugin for testing BetterDiscord plugin exports"
+    },
+    "main": "index.js"
+}

--- a/tests/plugins/Example 3/index.js
+++ b/tests/plugins/Example 3/index.js
@@ -1,0 +1,18 @@
+module.exports = (Plugin, Api, Vendor) => {
+
+    const { $, moment } = Vendor;
+    const { Events, Logger } = Api;
+
+    return class extends Plugin {
+        async onstart() {
+            const example_plugin = await Api.require('example-plugin');
+            console.log('Example plugin exports:', example_plugin.test1());
+        }
+
+        async onstop() {
+            const example_plugin = await Api.require('example-plugin');
+            console.log('Example plugin exports:', example_plugin.test2());
+        }
+    }
+
+};

--- a/tests/plugins/Example/config.json
+++ b/tests/plugins/Example/config.json
@@ -1,5 +1,6 @@
 {
     "info": {
+        "id": "example-plugin",
         "name": "Example Plugin",
         "authors": [ "Jiiks" ],
         "version": 1.0,

--- a/tests/plugins/Example/index.js
+++ b/tests/plugins/Example/index.js
@@ -21,6 +21,16 @@ module.exports = (Plugin, Api, Vendor) => {
             Logger.log(e);
         }
 
+        getExports() {
+            return {
+                test1: this.test1.bind(this),
+                test2: this.test2.bind(this)
+            };
+        }
+
+        test1() { return 'It works!'; }
+        test2() { return 'This works too!'; }
+
         settingChanged(category, setting_id, value) {
             if (!this.enabled) return;
             Logger.log(`${category}/${setting_id} changed to ${value}`);


### PR DESCRIPTION
Basically a plugin can define a `getExports` function (or just a getter for the `exports` property):

```js
// The default getter for the `exports` property will cache this
getExports() {
    return 'some plugin exports';
}

```

Which other plugins can access through the plugin API:

```js
const some_plugin_exports = await Api.require('some-plugin');
// some_plugin_exports === 'some plugin exports'

```