### PR TITLE
Color theme setting type

### DIFF
--- a/client/src/modules/thememanager.js
+++ b/client/src/modules/thememanager.js
@@ -150,6 +150,11 @@ export default class ThemeManager extends ContentManager {
             return [name, setting.options.find(opt => opt.id === value).value];
         }
 
+        if (type === 'color') {
+            console.log(value);
+            return [name, value];
+        }
+
         if (typeof value === 'boolean' || typeof value === 'number') {
             return [name, value];
         }
@@ -157,6 +162,10 @@ export default class ThemeManager extends ContentManager {
         if (typeof value === 'string') {
             return [name, this.toSCSSString(value)];
         }
+    }
+
+    static deQuote(value) {
+        return value.replace('"', '');
     }
 
     static toSCSSString(value) {

--- a/client/src/styles/partials/generic/forms/color.scss
+++ b/client/src/styles/partials/generic/forms/color.scss
@@ -1,0 +1,40 @@
+.bd-form-colorinput {
+    h3 {
+        + .bd-colorinput-wrapper {
+            width: 180px;
+        }
+    }
+
+    .bd-colorinput-wrapper {
+        margin-left: 15px;
+    }
+
+    input[type="color"] {
+        background: transparent;
+        border: none;
+        border-bottom: 2px solid rgba(114, 118, 126, 0.3);
+        outline: none;
+        width: 100%;
+
+    }
+
+    .bd-form-item-fullwidth & {
+        .bd-title {
+            flex-direction: column;
+        }
+
+        .bd-colorinput-wrapper {
+            width: 100%;
+            margin-top: 10px;
+            margin-left: 0;
+        }
+
+        .bd-hint {
+            margin-top: 10px;
+        }
+    }
+}
+
+.bd-colorinput-wrapper {
+    width: 100%;
+}

--- a/client/src/styles/partials/generic/forms/main.scss
+++ b/client/src/styles/partials/generic/forms/main.scss
@@ -6,7 +6,8 @@
 .bd-form-numberinput,
 .bd-form-slider,
 .bd-setting-switch,
-.bd-form-settingsarray {
+.bd-form-settingsarray,
+.bd-form-colorinput {
     .bd-title {
         display: flex;
 

--- a/client/src/ui/components/bd/setting/Color.vue
+++ b/client/src/ui/components/bd/setting/Color.vue
@@ -1,0 +1,31 @@
+/**
+ * BetterDiscord Setting Color Component
+ * Copyright (c) 2015-present Jiiks/JsSucks - https://github.com/Jiiks / https://github.com/JsSucks
+ * All rights reserved.
+ * https://betterdiscord.net
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+<template>
+    <div class="bd-form-colorinput">
+        <div class="bd-title">
+            <h3 v-if="setting.text">{{setting.text}}</h3>
+            <div class="bd-colorinput-wrapper">
+                <input type="color" :value="setting.value" @keyup.stop @input="input"/>
+            </div>
+        </div>
+        <div class="bd-hint">{{setting.hint}}</div>
+    </div>
+</template>
+<script>
+    export default {
+        props: ['setting', 'change'],
+        methods: {
+            input(e) {
+                this.change(e.target.value);
+            }
+        }
+    }
+</script>

--- a/client/src/ui/components/bd/setting/Setting.vue
+++ b/client/src/ui/components/bd/setting/Setting.vue
@@ -20,6 +20,7 @@
         <FileSetting v-if="setting.type === 'file'" :setting="setting" :change="change"/>
         <ArraySetting v-if="setting.type === 'array'" :setting="setting" :change="change" />
         <CustomSetting v-if="setting.type === 'custom'" :setting="setting" :change="change" />
+        <ColorSetting v-if="setting.type === 'color'" :setting="setting" :change="change" />
         <div class="bd-form-divider"></div>
     </div>
 </template>
@@ -35,6 +36,7 @@
     import FileSetting from './File.vue';
     import ArraySetting from './Array.vue';
     import CustomSetting from './Custom.vue';
+    import ColorSetting from './Color.vue';
 
     export default {
         props: [
@@ -51,7 +53,8 @@
             SliderSetting,
             FileSetting,
             ArraySetting,
-            CustomSetting
+            CustomSetting,
+            ColorSetting
         },
         computed: {
             changed() {
@@ -62,4 +65,5 @@
             }
         }
     }
+
 </script>


### PR DESCRIPTION
Added a color theme setting type using `<input type="color">`
For consistency you may want to change this to use a library like [jscolor](http://jscolor.com) for the color picker, as the behavior of type=color is to use the platform's native color picker. Another advantage of using a library would be the ability to theme it like everything else.