### PR TITLE
Fix class normalizer

### DIFF
--- a/client/src/ui/classnormaliser.js
+++ b/client/src/ui/classnormaliser.js
@@ -10,10 +10,12 @@
 
 import { Module, WebpackModules } from 'modules';
 
+const randClass = new RegExp(`^(?!da-)((?:[A-Za-z]|[0-9]|-)+)-(?:[A-Za-z]|[0-9]|-|_){6}$`);
+
 export default class ClassNormaliser extends Module {
 
     init() {
-        this.patchClassModules(WebpackModules.getModule(this.moduleFilter, false));
+        this.patchClassModules(WebpackModules.getModule(this.moduleFilter.bind(this), false));
     }
 
     patchClassModules(modules) {
@@ -22,16 +24,25 @@ export default class ClassNormaliser extends Module {
         }
     }
 
+    shouldIgnore(value) {
+        if (!isNaN(value)) return true;
+        if (value.endsWith("px") || value.endsWith("ch") || value.endsWith("em") || value.endsWith("ms")) return true;
+        if (value.startsWith("rgba")) return true;
+        if (value.includes("calc(")) return true;
+        return false;
+    }
+
     moduleFilter(module) {
         if (typeof module !== 'object' || Array.isArray(module)) return false;
         if (Array.isArray(module)) return false;
         if (module.__esModule) return false;
         if (!Object.keys(module).length) return false;
         for (let baseClassName in module) {
-            if (typeof module[baseClassName] !== 'string') return false;
-            if (module[baseClassName].split('-').length === 1) return false;
-            const alphaNumeric = module[baseClassName].split(/-(.+)/)[1].split(' ')[0];
-            if (alphaNumeric.length !== 6) return false;
+            const value = module[baseClassName];
+            if (typeof value !== 'string') return false;
+            if (this.shouldIgnore(value)) continue;
+            if (value.split('-').length === 1) return false;
+            if (!randClass.test(value.split(' ')[0])) return false;
         }
 
         return true;
@@ -39,8 +50,15 @@ export default class ClassNormaliser extends Module {
 
     patchClassModule(componentName, classNames) {
         for (let baseClassName in classNames) {
-            const normalised = baseClassName.split('-')[0].replace(/[A-Z]/g, m => `-${m}`).toLowerCase();
-            classNames[baseClassName] += ` ${componentName}-${normalised}`;
+            const value = classNames[baseClassName];
+            if (this.shouldIgnore(value)) continue;
+            const classList = value.split(" ");
+            for (let normalClass of classList) {
+                const match = normalClass.match(randClass)[1];
+                if (!match) continue; // Shouldn't ever happen since they passed the moduleFilter, but you never know
+                const camelCase = match.split('-').map((s, i) => i ? s[0].toUpperCase() + s.slice(1) : s).join("");
+                classNames[baseClassName] += ` ${componentName}-${camelCase}`;
+            }
         }
     }
 

--- a/client/src/ui/classnormaliser.js
+++ b/client/src/ui/classnormaliser.js
@@ -26,15 +26,14 @@ export default class ClassNormaliser extends Module {
 
     shouldIgnore(value) {
         if (!isNaN(value)) return true;
-        if (value.endsWith("px") || value.endsWith("ch") || value.endsWith("em") || value.endsWith("ms")) return true;
-        if (value.startsWith("rgba")) return true;
-        if (value.includes("calc(")) return true;
+        if (value.endsWith('px') || value.endsWith('ch') || value.endsWith('em') || value.endsWith('ms')) return true;
+        if (value.startsWith('rgba')) return true;
+        if (value.includes('calc(')) return true;
         return false;
     }
 
     moduleFilter(module) {
         if (typeof module !== 'object' || Array.isArray(module)) return false;
-        if (Array.isArray(module)) return false;
         if (module.__esModule) return false;
         if (!Object.keys(module).length) return false;
         for (let baseClassName in module) {
@@ -52,11 +51,11 @@ export default class ClassNormaliser extends Module {
         for (let baseClassName in classNames) {
             const value = classNames[baseClassName];
             if (this.shouldIgnore(value)) continue;
-            const classList = value.split(" ");
+            const classList = value.split(' ');
             for (let normalClass of classList) {
                 const match = normalClass.match(randClass)[1];
                 if (!match) continue; // Shouldn't ever happen since they passed the moduleFilter, but you never know
-                const camelCase = match.split('-').map((s, i) => i ? s[0].toUpperCase() + s.slice(1) : s).join("");
+                const camelCase = match.split('-').map((s, i) => i ? s[0].toUpperCase() + s.slice(1) : s).join('');
                 classNames[baseClassName] += ` ${componentName}-${camelCase}`;
             }
         }


### PR DESCRIPTION
- Adds ignores for things stored alongside classes in certain modules like font-sizes and such
- Switch to the `da-className` style that was voted on
- Normalizes all classes in a list instead of just one (They often reuse values in other lists so when another state is being used, the original normalized name isn't there. e.g. for user popout headers discord's value for header is `header-2BwW8b size16-14cGz5` and their value for playing header is `headerPlaying-j0WQBV header-2BwW8b size16-14cGz5` which means `header-2BwW8b` wouldn't be normalized for playing headers)
- Remove redundant array check