### PR TITLE
Missing one round bracket, causes gulp build error

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -81,7 +81,7 @@ gulp.task('node-sass-bindings', gulp.series(function () {
         gulp.src('other/node_sass_bindings/**/*'),
         copy('release/node_modules/node-sass/vendor', { prefix: 2 })
     ]);
-});
+}));
 
 gulp.task('keytar-bindings', gulp.series(function () {
     return del(['release/node_modules/keytar/build']);


### PR DESCRIPTION
And btw, it needs (for linux) libsecret-1 since the last commit, else there will be compilation errors. (libsecret-1-dev for debian/ubuntu).