### PR TITLE
Fixed Darwin path in scripts/inject.js

### DIFF
--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -15,7 +15,7 @@ const discordPath = (function() {
         return dir;
     }
     else if (process.platform == 'darwin') {
-        const dir = path.join('Applications', `${release}.app`, 'Contents', 'Resources');
+        const dir = path.join('/Applications', `${release}.app`, 'Contents', 'Resources');
         if (!fs.existsSync(dir)) throw new Error(`Cannot find directory for ${release}`);
         return dir;
     }


### PR DESCRIPTION
initially running `npm run inject` threw `Error: Cannot find directory for Discord` - i fixed this by adding a forward slash to the path in the inject script.