### PR TITLE
Fix MessageContent not being found in multiple builtins

### DIFF
--- a/client/src/builtin/ColoredText.js
+++ b/client/src/builtin/ColoredText.js
@@ -50,7 +50,7 @@ export default new class ColoredText extends BuiltinModule {
     /* Patches */
     async applyPatches() {
         if (this.patches.length) return;
-        this.MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector });
+        this.MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector }, m => m.defaultProps && m.defaultProps.hasOwnProperty('disableButtons'));
         this.patch(this.MessageContent.component.prototype, 'render', this.injectColoredText);
         this.MessageContent.forceUpdateAll();
     }
@@ -58,10 +58,12 @@ export default new class ColoredText extends BuiltinModule {
     /**
      * Set markup text colour to match role colour
      */
-    injectColoredText(thisObject, args, returnValue) {
-        const { TinyColor } = Reflection.modules;
-        const markup = Utils.findInReactTree(returnValue, m => m && m.props && m.props.className && m.props.className.includes('da-markup'));
-        const roleColor = thisObject.props.message.colorString;
-        if (markup && roleColor) markup.props.style = {color: TinyColor.mix(roleColor, this.defaultColor, this.intensity)};
+    injectColoredText(thisObject, args, originalReturn) {
+        this.patch(originalReturn.props, 'children', function(obj, args, returnValue) {
+            const { TinyColor } = Reflection.modules;
+            const markup = Utils.findInReactTree(returnValue, m => m && m.props && m.props.className && m.props.className.includes('da-markup'));
+            const roleColor = thisObject.props.message.colorString;
+            if (markup && roleColor) markup.props.style = {color: TinyColor.mix(roleColor, this.defaultColor, this.intensity)};
+        });
     }
 }

--- a/client/src/builtin/E2EE.js
+++ b/client/src/builtin/E2EE.js
@@ -236,7 +236,7 @@ export default new class E2EE extends BuiltinModule {
     }
 
     async patchMessageContent() {
-        const MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector });
+        const MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector }, m => m.defaultProps && m.defaultProps.hasOwnProperty('disableButtons'));
         this.patch(MessageContent.component.prototype, 'render', this.beforeRenderMessageContent, 'before');
         this.patch(MessageContent.component.prototype, 'render', this.afterRenderMessageContent);
 

--- a/client/src/builtin/EmoteModule.js
+++ b/client/src/builtin/EmoteModule.js
@@ -226,7 +226,7 @@ export default new class EmoteModule extends BuiltinModule {
      * Patches MessageContent render method
      */
     async patchMessageContent() {
-        const MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector });
+        const MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector }, m => m.defaultProps && m.defaultProps.hasOwnProperty('disableButtons'));
         this.patch(MessageContent.component.prototype, 'render', this.afterRenderMessageContent);
         MessageContent.forceUpdateAll();
     }

--- a/tests/ext/plugins/Render Example/index.js
+++ b/tests/ext/plugins/Render Example/index.js
@@ -30,7 +30,7 @@ module.exports = (Plugin, Api, Vendor) => {
             // Force update elements to remove our changes
             const GuildTextChannel = await ReactComponents.getComponent('GuildTextChannel');
             GuildTextChannel.forceUpdateAll();
-            const MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector });
+            const MessageContent = await ReactComponents.getComponent('MessageContent', { selector: Reflection.resolve('container', 'containerCozy', 'containerCompact', 'edited').selector }, m => m.defaultProps && m.defaultProps.hasOwnProperty('disableButtons'));
             MessageContent.forceUpdateAll();
             return true;
         }


### PR DESCRIPTION
Discord updated the MessageContent to be wrapped in a context so the children are a weird wrapped function instead of an array, this filter added forces it to find the right component.