### PR TITLE
Fix for new context wrappers in Discord

### DIFF
--- a/client/src/modules/reactcomponents.js
+++ b/client/src/modules/reactcomponents.js
@@ -131,7 +131,8 @@ class Helpers {
     static findByProp(obj, what, value) {
         if (obj.hasOwnProperty(what) && obj[what] === value) return obj;
         if (obj.props && !obj.children) return this.findByProp(obj.props, what, value);
-        if (!obj.children || !obj.children.length) return null;
+        if (!obj.children) return null;
+        if (!(obj.children instanceof Array)) return this.findByProp(obj.children, what, value);
         for (const child of obj.children) {
             if (!child) continue;
             const findInChild = this.findByProp(child, what, value);


### PR DESCRIPTION
The new context wrappers cause several components to have their `children` property be a function that is passed parameters before the children are eventually rendered. Due to that when we are doing react reflection we need to have a check for that since it caused a lot of errors. They also seem to had a valid length so the previous length check didn't somehow catch it.