### PR TITLE
Add dnd in non-channels and fix upload failover

### DIFF
--- a/client/src/ui/components/bd/modals/InstallModal.vue
+++ b/client/src/ui/components/bd/modals/InstallModal.vue
@@ -33,16 +33,16 @@
             </div>
             <div v-else-if="!verified" slot="footer" class="bd-installModalFooter">
                 <span class="bd-installModalStatus bd-err">Not verified!</span>
-                <div class="bd-button bd-installModalUpload" @click="modal.confirm(0); modal.close();">Upload</div>
+                <div class="bd-button bd-installModalUpload" @click="modal.confirm(0); modal.close();" v-if="modal.canUpload">Upload</div>
                 <div class="bd-button bd-err" @click="install" v-if="allowUnsafe">{{ !alreadyInstalled ? 'Install' : 'Update' }}</div>
             </div>
             <div v-else-if="alreadyInstalled && upToDate" slot="footer" class="bd-installModalFooter">
                 <span class="bd-installModalStatus">Up to date version already installed!</span>
-                <div class="bd-button bd-installModalUpload" @click="modal.confirm(0); modal.close();">Upload</div>
+                <div class="bd-button bd-installModalUpload" @click="modal.confirm(0); modal.close();" v-if="modal.canUpload">Upload</div>
             </div>
             <div v-else slot="footer" class="bd-installModalFooter">
                 <span class="bd-installModalStatus bd-ok">Verified!</span>
-                <div class="bd-button bd-installModalUpload" @click="modal.confirm(0); modal.close();">Upload</div>
+                <div class="bd-button bd-installModalUpload" @click="modal.confirm(0); modal.close();" v-if="modal.canUpload">Upload</div>
                 <div class="bd-button bd-ok" @click="install">{{ !alreadyInstalled ? 'Install' : 'Update' }}</div>
             </div>
         </template>

--- a/client/src/ui/modals.js
+++ b/client/src/ui/modals.js
@@ -191,12 +191,12 @@ export default class Modals {
         return new Modal(modal, InputModal);
     }
 
-    static installModal(contentType, config, filePath, icon) {
-        return this.add(this.createInstallModal(contentType, config, filePath, icon));
+    static installModal(contentType, config, filePath, icon, canUpload = false) {
+        return this.add(this.createInstallModal(contentType, config, filePath, icon, canUpload));
     }
 
-    static createInstallModal(contentType, config, filePath, icon) {
-        const modal = { contentType, config, filePath, icon };
+    static createInstallModal(contentType, config, filePath, icon, canUpload = false) {
+        const modal = { contentType, config, filePath, icon, canUpload };
         modal.promise = new Promise((resolve, reject) => {
             modal.confirm = value => resolve(value);
             modal.beforeClose = () => reject();


### PR DESCRIPTION
Lets the Drag-n-Drop package installer work in screens without a chat window and fixes the upload button so you can upload instead.