### PR TITLE
Fix #303, Try 3

### DIFF
--- a/client/src/builtin/Emotes/EmoteModule.js
+++ b/client/src/builtin/Emotes/EmoteModule.js
@@ -282,7 +282,7 @@ export default new class EmoteModule extends BuiltinModule {
         Logger.log('EmoteModule', ['Sending message', MessageActions, args, orig]);
 
         const emoteAsImage = Settings.getSetting('emotes', 'default', 'emoteasimage').value &&
-            (DiscordApi.currentChannel.type === 'DM' || DiscordApi.currentChannel.checkPermissions(DiscordApi.modules.DiscordPermissions.ATTACH_FILES));
+            (DiscordApi.currentChannel.type === 'DM' || DiscordApi.currentChannel.type === 'GROUP_DM' || DiscordApi.currentChannel.checkPermissions(DiscordApi.modules.DiscordPermissions.ATTACH_FILES));
 
         if (!emoteAsImage || content.split(' ').length > 1) {
             args[1].content = args[1].content.split(' ').map(word => {


### PR DESCRIPTION
This allows sending emotes as images in Group DMs (and allows sending messages in Group DMs when emotes are enabled).

Resubmission number 3, since the file was moved and the last one got conflicted.